### PR TITLE
#31 do not cut ldapsearch results after 79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent ldapsearch results from being cut after 79 characters (#31)
 
 ## [v2.6.2-2] - 2022-09-08
-
 ### Changed
 - Make sure socket path exists and use default socket path for ldap connections at dogu startup as it was before 2.6.2-1
 - Move migration logic from startup script to `post-upgrade.sh`

--- a/resources/send-mail-after-changed-password.sh
+++ b/resources/send-mail-after-changed-password.sh
@@ -29,7 +29,7 @@ OPENLDAP_SUFFIX="dc=cloudogu,dc=com"
 LDAP_SEARCHBASE="ou=people,o=${LDAP_DOMAIN},${OPENLDAP_SUFFIX}"
 LDAP_SEARCHFILTER="(&(uid=*)(objectClass=inetOrgPerson))"
 LDAP_SEARCH_BIN="/usr/bin/ldapsearch"
-ldap_param="-LLL -Q"
+ldap_param="-LLL -Q -o ldif-wrap=no"
 
 # Relevant LDAP attributes of a user
 #   CN: Common name of the user


### PR DESCRIPTION
- long usernames would be seperated over multiple lines

Resolves #31 