### PR TITLE
[#51] Add config to adjust the maximum size of the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [#51] Added config to adjust the maximum size of the database 
 
 ## [v2.6.8-1] - 2024-12-19
 ### Changed

--- a/dogu.json
+++ b/dogu.json
@@ -95,6 +95,12 @@
       "Description": "Set how many users can be retrieved in a single search operation",
       "Optional": true,
       "Default": "4000"
+    },
+    {
+      "Name": "max_db_size",
+      "Description": "Specify the maximum size of the database in bytes. A memory map of this size is allocated at startup time and the database will not be allowed to grow beyond this size.",
+      "Optional": true,
+      "Default": "104857600"
     }
   ],
   "Volumes": [

--- a/resources/set-mdb-size-limit.sh
+++ b/resources/set-mdb-size-limit.sh
@@ -1,0 +1,31 @@
+
+function setMdbSizeLimit() {
+  mdb_size_limit=$(doguctl config max_db_size)
+  echo "#DOGU max_db_size is ${mdb_size_limit}"
+
+  # Retrieve the current size limit
+  current_size_limit=$(ldapsearch -b olcDatabase={1}mdb,cn=config | grep olcDbMaxSize | awk '{print $2}') || current_size_limit=0
+  current_size_limit=${current_size_limit:-0}
+
+  echo "current_size_limit: $current_size_limit"
+
+  if [ "$mdb_size_limit" -gt "$current_size_limit" ]; then
+    if [ "$current_size_limit" -eq "0" ]; then
+      echo "[SET-MDB-DB-SIZE-LIMIT] No current size limit found. Setting new limit."
+    else
+      echo "[SET-MDB-DB-SIZE-LIMIT] Updating database size limit to ($mdb_size_limit)."
+    fi
+
+    ldapmodify <<EOF
+dn: olcDatabase={1}mdb,cn=config
+changetype: modify
+replace: olcDbMaxSize
+olcDbMaxSize: $mdb_size_limit
+EOF
+
+  else
+    echo "[SET-MDB-DB-SIZE-LIMIT] Current size limit ($current_size_limit) is greater than or equal to the new limit ($mdb_size_limit). No changes made."
+  fi
+
+  echo "[SET-MDB-DB-SIZE-LIMIT] Current maximum database size: $(ldapsearch -b olcDatabase={1}mdb,cn=config | grep olcDbMaxSize)"
+}

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -30,6 +30,9 @@ source install-sss-vlv.sh
 source increase-user-search-limit.sh
 
 # shellcheck disable=SC1091
+source set-mdb-size-limit.sh
+
+# shellcheck disable=SC1091
 source /scheduled_jobs.sh
 
 LOGLEVEL=${LOGLEVEL:-0}
@@ -231,6 +234,7 @@ installPwdPolicyIfNecessary
 installCespersonIfNecessary
 installSSSVLVIfNecessary
 increaseUserSearchLimit
+setMdbSizeLimit
 
 stopInitDBDaemon
 


### PR DESCRIPTION
The default value for the maximum size of the mdb database is set to 10MB. This commit enables the option to easily increase the maximum size of the database via doguctl.

The maximum size can only be increased. Providing values lower than the current limit will have no effect.