### PR TITLE
#53 Add missing config keys to dogu descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [#53] Added missing config keys to dogu descriptor.
+  This is to distinguish dogu config from local config during the migration to multinode.
+### Changed
+- Consistently use doguctl to retrieve `openldap_suffix` instead of hardcoding it in some cases.
 
 ## [v2.6.8-2] - 2025-01-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#53] Added missing config keys to dogu descriptor.
   This is to distinguish dogu config from local config during the migration to multinode.
+- Volume for local config
 ### Changed
 - Consistently use doguctl to retrieve `openldap_suffix` instead of hardcoding it in some cases.
 

--- a/dogu.json
+++ b/dogu.json
@@ -101,6 +101,59 @@
       "Description": "Specify the maximum size of the database in bytes. A memory map of this size is allocated at startup time and the database will not be allowed to grow beyond this size.",
       "Optional": true,
       "Default": "104857600"
+    },
+    {
+      "Name": "rootpwd",
+      "Description": "The LDAP root password (olcRootPW). If left unset, a random password will be generated.",
+      "Optional": true,
+      "Encrypted": true
+    },
+    {
+      "Name": "admin_username",
+      "Description": "The username of the CES admin. Usually, this is set during setup.",
+      "Optional": true,
+      "Default": "admin"
+    },
+    {
+      "Name": "admin_member",
+      "Description": "Specifies if the CES admin is also admin in other dogus.",
+      "Optional": true,
+      "Default": "false"
+    },
+    {
+      "Name": "admin_givenname",
+      "Description": "Specifies the givenName attribute of the CES admin in the LDAP.",
+      "Optional": true,
+      "Default": "admin"
+    },
+    {
+      "Name": "admin_surname",
+      "Description": "Specifies the sn attribute of the CES admin in the LDAP.",
+      "Optional": true,
+      "Default": "admin"
+    },
+    {
+      "Name": "admin_displayname",
+      "Description": "Specifies the displayName attribute of the CES admin in the LDAP.",
+      "Optional": true,
+      "Default": "admin"
+    },
+    {
+      "Name": "admin_mail",
+      "Description": "Specifies the mail attribute of the CES admin in the LDAP. Defaults to <admin_username>@<ces-domain>.",
+      "Optional": true
+    },
+    {
+      "Name": "admin_password",
+      "Description": "Specifies the userPassword attribute of the CES admin in the LDAP.",
+      "Optional": false,
+      "Encrypted": true
+    },
+    {
+      "Name": "openldap_suffix",
+      "Description": "Specifies general suffix used for the ldap hierarchy.",
+      "Optional": true,
+      "Default": "dc=cloudogu,dc=com"
     }
   ],
   "Volumes": [

--- a/dogu.json
+++ b/dogu.json
@@ -21,8 +21,42 @@
   ],
   "Configuration": [
     {
+      "Name": "container_config/cpu_core_limit",
+      "Description": "Limits the container's CPU core usage. Use a positive floating value describing a fraction of 1 CPU core. When you define a value of '0.5', you are requesting half as much CPU time compared to if you asked for '1.0' CPU.",
+      "Optional": true
+    },
+    {
+      "Name": "container_config/cpu_core_request",
+      "Description": "Requests the container's minimal CPU core requirement. Use a positive floating value describing a fraction of 1 CPU core. When you define a value of '0.5', you are requesting half as much CPU time compared to if you asked for '1.0' CPU.",
+      "Optional": true
+    },
+    {
       "Name": "container_config/memory_limit",
-      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte)",
+      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/memory_request",
+      "Description": "Requests the container's minimal memory requirement. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/storage_limit",
+      "Description": "Limits the container's ephemeral storage usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/storage_request",
+      "Description": "Requests the container's minimal ephemeral storage requirement. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"

--- a/dogu.json
+++ b/dogu.json
@@ -211,6 +211,13 @@
       "Owner": "100",
       "Group": "101",
       "NeedsBackup": false
+    },
+    {
+      "Name": "localConfig",
+      "Path": "/var/ces/config",
+      "Owner": "100",
+      "Group": "101",
+      "NeedsBackup": true
     }
   ],
   "ExposedCommands": [

--- a/resources/send-mail-after-changed-password.sh
+++ b/resources/send-mail-after-changed-password.sh
@@ -24,7 +24,7 @@ log_debug "Start the detection of changed user passwords since ${START_OF_THE_PE
 
 # Configuration of the LDAP and of LDAP search
 LDAP_DOMAIN="$(doguctl config --global domain)"
-OPENLDAP_SUFFIX="dc=cloudogu,dc=com"
+OPENLDAP_SUFFIX=$(doguctl config openldap_suffix --default "dc=cloudogu,dc=com")
 
 LDAP_SEARCHBASE="ou=people,o=${LDAP_DOMAIN},${OPENLDAP_SUFFIX}"
 LDAP_SEARCHFILTER="(&(uid=*)(objectClass=inetOrgPerson))"

--- a/resources/srv/openldap/create-sa.sh
+++ b/resources/srv/openldap/create-sa.sh
@@ -24,8 +24,7 @@
 
     LDAP_DOMAIN=$(doguctl config --global domain)
     export LDAP_DOMAIN
-    # proposal: use doguctl config openldap_suffix in future
-    OPENLDAP_SUFFIX="dc=cloudogu,dc=com"
+    OPENLDAP_SUFFIX=$(doguctl config openldap_suffix --default "dc=cloudogu,dc=com")
     export OPENLDAP_SUFFIX
 
     # create random schema suffix and password

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -50,8 +50,8 @@ export OPENLDAP_BACKEND_DATABASE="mdb"
 export OPENLDAP_BACKEND_OBJECTCLASS="olcMdbConfig"
 OPENLDAP_ULIMIT="2048"
 
-# proposal: use doguctl config openldap_suffix in future
-export OPENLDAP_SUFFIX="dc=cloudogu,dc=com"
+OPENLDAP_SUFFIX=$(doguctl config openldap_suffix --default "dc=cloudogu,dc=com")
+export OPENLDAP_SUFFIX
 
 # migration tmp folder
 export MIGRATION_TMP_DIR="/tmp/migration"


### PR DESCRIPTION
This is to distinguish dogu config from local config during the migration.

Resolves #53 